### PR TITLE
 fix: error silencioso al realizar muchas búsquedas de repositorios

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
     "clsx": "2.1.1",
     "cmdk": "1.1.1",
     "highlight.js": "11.11.1",
+    "http-sentinel": "^1.0.9",
     "lucide-react": "0.525.0",
     "next-themes": "0.4.6",
     "react": "19.1.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -47,6 +47,9 @@ importers:
       highlight.js:
         specifier: 11.11.1
         version: 11.11.1
+      http-sentinel:
+        specifier: ^1.0.9
+        version: 1.0.9
       lucide-react:
         specifier: 0.525.0
         version: 0.525.0(react@19.1.0)
@@ -2301,6 +2304,9 @@ packages:
   http-proxy-agent@7.0.2:
     resolution: {integrity: sha512-T1gkAiYYDWYx3V5Bmyu7HcfcvL7mUrTWiM6yOfa3PIphViJ/gFPbvidQ+veqSOHci/PxBcDabeUNCzpOODJZig==}
     engines: {node: '>= 14'}
+
+  http-sentinel@1.0.9:
+    resolution: {integrity: sha512-IK+q68OHY7c89E5e1NLZJGm1LaAohx9p2rcbVCelaahGUZoIfvhX3rhts7JxS/yuPUiGaaod6B+MfkPLEalzIg==}
 
   https-proxy-agent@7.0.6:
     resolution: {integrity: sha512-vK9P5/iUfdl95AI+JVyUuIcVtd4ofvtrOr3HNtM2yxC9bnMbEdp3x01OhQNnjb8IJYi38VlTE3mBXwcfvywuSw==}
@@ -6051,6 +6057,8 @@ snapshots:
       debug: 4.4.1
     transitivePeerDependencies:
       - supports-color
+
+  http-sentinel@1.0.9: {}
 
   https-proxy-agent@7.0.6:
     dependencies:

--- a/src/components/app/error-container.tsx
+++ b/src/components/app/error-container.tsx
@@ -1,0 +1,17 @@
+import * as Sentinel from 'http-sentinel'
+
+// soruce https://www.npmjs.com/package/http-sentinel //
+
+type IError = { error: Sentinel.ExpectedError }
+
+export const ErrorContainer: React.FC<IError> = ({ error }) => {
+  const msg = Sentinel.check_error_type(error, Sentinel.Forbidden)
+    ? 'Demasiadas peticiones'
+    : Sentinel.check_error_type(error, Sentinel.ServiceUnavailable || Sentinel.InternalServer)
+      ? 'Se produjo un error en el servidor'
+      : Sentinel.check_error_type(error, Sentinel.TooManyRequests)
+        ? 'Muchas peticiones, intenta luego'
+        : 'Error desconocido'
+
+  return (<p className='text-center text-red-500'>{msg}</p>)
+}


### PR DESCRIPTION
## Problema actual

Cuando se realizan numerosas búsquedas de repositorios de manera anónima (sin autenticación), la API de GitHub devuelve un **403 Forbidden**, pero la interfaz de usuario no muestra ninguna indicación del motivo real del fallo, quedando el sistema en un estado de error silencioso y generando mala experiencia de usuario.


![zuma_1](https://github.com/user-attachments/assets/059c9664-3b98-4546-9db9-03539a1e801d)

## Solución implementada

1. **Instalación de la dependencia `http-sentinel`**

   * Se incorpora `http-sentinel` para centralizar el manejo de errores HTTP y filtrar respuestas según su código de estado.
   (Fuente: https://www.npmjs.com/package/http-sentinel)

2. **Detección explícita de códigos de error**

   * En  (`searchRepos`), se intercepta el código **403** para peticiones anónimas y el **429** en caso de ráfagas excesivas.
   * Para cada código identificado, se construye un mensaje de error claro y descriptivo:

     * **403**: "Demasiadas peticiones"
     * **429**: "Muchas peticiones, intenta luego"


3. **Limpieza de errores previos**

   * Si la petición se completa con éxito, se limpia cualquier estado de error previo para restaurar la interfaz a su comportamiento normal.

![zuma_2](https://github.com/user-attachments/assets/8daeb8a2-1db8-4778-8ca2-27a9f7e1f20f)

## Beneficios

* **Experiencia de usuario mejorada**: El usuario recibe información clara sobre por qué falló la búsqueda.
* **Mantenimiento**: El uso de `http-sentinel` centraliza y simplifica el manejo de errores HTTP.
* **Escalabilidad**: Facilita la extensión futura para otros códigos de estado o flujos de autenticación.

---